### PR TITLE
Update API logic for set references and images

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,17 +19,14 @@ Eine einfache, offene API für Pokémon TCG Pocket Kartendaten – bereitgestell
    python3 -m venv .venv
    source .venv/bin/activate
    ```
-
 2. Abhängigkeiten installieren
    ```bash
    pip install -r requirements.txt
    ```
-
 3. API lokal starten
    ```bash
    uvicorn main:app --reload
    ```
-
 
 ---
 ## Endpunkte
@@ -39,8 +36,9 @@ Eine einfache, offene API für Pokémon TCG Pocket Kartendaten – bereitgestell
 `GET /cards`
 
 - **Antwort:** Array mit allen Karten als JSON-Objekte
+- Optionaler Query-Parameter `lang` wählt die Sprache für das Kartenbild (Standard: `en`)
 
-**Beispiel:**  
+**Beispiel:**
 `https://ptcgp-api-production.up.railway.app/cards`
 
 ---
@@ -49,10 +47,11 @@ Eine einfache, offene API für Pokémon TCG Pocket Kartendaten – bereitgestell
 
 `GET /cards/{card_id}`
 
-- `{card_id}` ist die eindeutige ID der Karte (z. B. “002”)
-- **Antwort:** JSON-Objekt der Karte
+- `{card_id}` ist die globale ID der Karte (z. B. `002`)
+- Optionaler Query-Parameter `lang` für das Kartenbild
+- **Antwort:** JSON-Objekt der Karte inklusive Set-Informationen und Bild-URL
 
-**Beispiel:**  
+**Beispiel:**
 `https://ptcgp-api-production.up.railway.app/cards/002`
 
 ---
@@ -60,25 +59,23 @@ Eine einfache, offene API für Pokémon TCG Pocket Kartendaten – bereitgestell
 ## Beispielantwort
 
 ```json
-[
-  {
-    "id": "002",
+{
+  "id": "002",
+  "name": {
+    "en": "Beispielkarte",
+    "de": "Beispielkarte"
+  },
+  "set": {
+    "id": "A2a",
     "name": {
-      "en": "Burmy",
-      "de": "Burmy"
-      // weitere Sprachen…
+      "en": "Triumphant Light",
+      "de": "Licht des Triumphs"
     },
-    "set": {
-      "id": "A2a",
-      "name": {
-        "en": "Triumphant Light",
-        "de": "Licht des Triumphs"
-      }
-    }
-    // weitere Felder wie illustrator, rarity, attacks, usw.
-  }
-  // weitere Karten
-]
+    "releaseDate": "2025-02-28"
+  },
+  "image": "https://assets.tcgdex.net/en/tcgp/A2a/002/high.webp"
+  // weitere Felder wie illustrator, rarity, attacks, ...
+}
 ```
 
 ---

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 import json
 import os
+import requests
 
 app = FastAPI()
 
@@ -13,25 +14,65 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-# Richtigen Pfad zur cards.json setzen (jetzt im eigenen Repo unter data/cards.json)
-cards_path = os.path.join(os.path.dirname(__file__), 'data', 'cards.json')
+# Pfade zu den Daten
+base_dir = os.path.dirname(__file__)
+cards_path = os.path.join(base_dir, 'data', 'cards.json')
+sets_path = os.path.join(base_dir, 'data', 'sets.json')
 
 if not os.path.exists(cards_path):
     raise FileNotFoundError(f"cards.json not found at {cards_path}")
+if not os.path.exists(sets_path):
+    raise FileNotFoundError(f"sets.json not found at {sets_path}")
 
-# Karten-Daten laden (einmalig beim Start)
+# Daten laden
 with open(cards_path, encoding='utf-8') as f:
-    cards = json.load(f)
+    _raw_cards = json.load(f)
+with open(sets_path, encoding='utf-8') as f:
+    _sets = {s["id"]: s for s in json.load(f)}
+
+# Karten vorbereiten: globale ID und lokale ID pro Set
+_cards = []
+_set_counter = {}
+for idx, card in enumerate(_raw_cards, start=1):
+    set_id = card.get("set_id")
+    _set_counter[set_id] = _set_counter.get(set_id, 0) + 1
+    card_obj = card.copy()
+    card_obj["id"] = f"{idx:03d}"
+    card_obj["_local_id"] = f"{_set_counter[set_id]:03d}"
+    _cards.append(card_obj)
+
+
+def _image_url(lang: str, set_id: str, local_id: str) -> str:
+    base = f"https://assets.tcgdex.net/{lang}/tcgp/{set_id}/{local_id}"
+    high = f"{base}/high.webp"
+    try:
+        resp = requests.head(high)
+        if resp.status_code == 200:
+            return high
+    except Exception:
+        pass
+    return f"{base}/low.webp"
 
 
 @app.get("/cards")
-def get_cards():
-    return cards
+def get_cards(lang: str = "en"):
+    result = []
+    for card in _cards:
+        c = card.copy()
+        c["set"] = _sets.get(c["set_id"])
+        c["image"] = f"https://assets.tcgdex.net/{lang}/tcgp/{c['set_id']}/{c['_local_id']}/high.webp"
+        del c["_local_id"]
+        result.append(c)
+    return result
 
 
 @app.get("/cards/{card_id}")
-def get_card(card_id: str):
-    for card in cards:
-        if card.get("id") == card_id:
-            return card
+def get_card(card_id: str, lang: str = "en"):
+    for card in _cards:
+        if card["id"] == card_id:
+            c = card.copy()
+            c["set"] = _sets.get(c["set_id"])
+            c["image"] = _image_url(lang, c["set_id"], c["_local_id"])
+            del c["_local_id"]
+            return c
     raise HTTPException(status_code=404, detail="Card not found")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 fastapi
 uvicorn[standard]
+requests


### PR DESCRIPTION
## Summary
- adapt API code to separate cards and sets data
- generate image URLs with fallback and assign sequential IDs
- document updated endpoints and example response
- add `requests` dependency

## Testing
- `python3 -m py_compile main.py`
- `python3 -m pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6847608553d0832f82e71c28ab2583b1