### PR TITLE
Add set listing endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,32 @@ Eine einfache, offene API für Pokémon TCG Pocket Kartendaten – bereitgestell
 
 ---
 
+### Alle Sets abrufen
+
+`GET /sets`
+
+- Optionaler Query-Parameter `lang` bestimmt die Sprache der Setnamen (Standard: `de`)
+- **Antwort:** Array mit allen Sets als JSON-Objekte
+
+**Beispiel:**
+`https://ptcgp-api-production.up.railway.app/sets`
+
+---
+
+### Einzelnes Set abrufen
+
+`GET /sets/{set_id}`
+
+- `{set_id}` ist die ID des Sets (z. B. `A2a`)
+- Optionaler Query-Parameter `lang` wählt die Sprache der Felder
+- **Antwort:** JSON-Objekt des Sets
+- Bei unbekannter ID wird `404` zurückgegeben.
+
+**Beispiel:**
+`https://ptcgp-api-production.up.railway.app/sets/A2a`
+
+---
+
 ## Beispielantwort
 
 

--- a/main.py
+++ b/main.py
@@ -111,3 +111,18 @@ def get_card(card_id: str, lang: str = "de"):
             del c["_local_id"]
             return _filter_language(c, lang)
     raise HTTPException(status_code=404, detail="Card not found")
+
+
+@app.get("/sets")
+def get_sets(lang: str = "de"):
+    """Liste aller Sets zurückgeben."""
+    return [_filter_language(s, lang) for s in _sets.values()]
+
+
+@app.get("/sets/{set_id}")
+def get_set(set_id: str, lang: str = "de"):
+    """Ein einzelnes Set abrufen."""
+    s = _sets.get(set_id)
+    if s is None:
+        raise HTTPException(status_code=404, detail="Set not found")
+    return _filter_language(s, lang)


### PR DESCRIPTION
## Summary
- add `/sets` and `/sets/{set_id}` routes
- document new endpoints with usage examples

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848a1fd4c30832fbce1c64b4599a8d3