### PR TITLE
Add structured search

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,11 @@ Eine einfache, offene API für Pokémon TCG Pocket Kartendaten – bereitgestell
 
 - Query-Parameter `q` legt den Suchbegriff fest
 - Optionaler Query-Parameter `lang` bestimmt Sprache von Text und Bild (Standard: `de`)
+- Optionaler Query-Parameter `fields` schränkt die Suche auf bestimmte Felder ein (`name`, `abilities`, `attacks`)
 - **Antwort:** Array mit Karten, die den Suchbegriff enthalten
 
 **Beispiel:**
-`GET /cards/search?q=Gift&lang=de`
+`GET /cards/search?q=Gift&fields=name,attacks&lang=de`
 
 ---
 


### PR DESCRIPTION
## Summary
- build in-memory index for card texts
- allow field-specific search for name, abilities or attacks
- document new search parameter in the README

## Testing
- `pytest -q`
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_6848a30ff370832f8f52f8b9d6537705