### PR TITLE
Implement image caching for API

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ Eine einfache, offene API für Pokémon TCG Pocket Kartendaten – bereitgestell
 - **Antwort:** JSON-Objekt der Karte inklusive Set-Informationen und Bild-URL
 - Ohne Angabe wird nur Deutsch ausgegeben.
 - Beispiel für Englisch: `/cards/{card_id}?lang=en`
+- Das hochauflösende Bild (`high.webp`) wird nur dann verwendet, wenn es existiert.
+  Das Ergebnis der ersten Prüfung wird zwischengespeichert, um weitere Anfragen
+  schneller zu beantworten.
 
 **Beispiel:**
 `https://ptcgp-api-production.up.railway.app/cards/002`

--- a/main.py
+++ b/main.py
@@ -5,6 +5,8 @@ import json
 import os
 import requests
 
+_image_cache = {}
+
 app = FastAPI()
 
 # CORS erlauben (z.B. für die Mobile-App)
@@ -66,12 +68,14 @@ def _filter_language(data, lang: str, default_lang: str = "de"):
 def _image_url(lang: str, set_id: str, local_id: str) -> str:
     base = f"https://assets.tcgdex.net/{lang}/tcgp/{set_id}/{local_id}"
     high = f"{base}/high.webp"
-    try:
-        resp = requests.head(high)
-        if resp.status_code == 200:
-            return high
-    except Exception:
-        pass
+    if high not in _image_cache:
+        try:
+            resp = requests.head(high)
+            _image_cache[high] = resp.status_code == 200
+        except Exception:
+            _image_cache[high] = False
+    if _image_cache[high]:
+        return high
     return f"{base}/low.webp"
 
 


### PR DESCRIPTION
## Summary
- add `_image_cache` dictionary to avoid redundant HEAD requests
- fallback to low-res images if `high.webp` is missing
- document cached high/low image selection

## Testing
- `pytest -q`
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_6848a311bbfc832f8d73eacff134ed47