### PR TITLE
Add category filter to card API

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,13 @@ Eine einfache, offene API für Pokémon TCG Pocket Kartendaten – bereitgestell
   - `set_id` – nur Karten eines bestimmten Sets
   - `type` – Pokémon-Typ oder Trainer-Typ
   - `rarity` – Seltenheit der Karte
+  - `category` – Kategorie der Karte (z. B. `Pokemon` oder `Trainer`)
   - `hp_min` / `hp_max` – minimale bzw. maximale KP
   - `limit` & `offset` – Pagination der Ergebnisse
 - Ohne Angabe wird nur Deutsch zurückgegeben.
 - Beispiel für Englisch: `/cards?lang=en`
-- Beispiel mit Filtern: `/cards?set_id=A2a&type=Metal&hp_min=100&limit=10`
+- Beispiel mit Filtern: `/cards?set_id=A2a&type=Metal&category=Pokemon&hp_min=100&limit=10`
+- Beispiel nur nach Kategorie: `/cards?category=Trainer`
 
 **Beispiel:**
 `https://ptcgp-api-production.up.railway.app/cards`

--- a/main.py
+++ b/main.py
@@ -115,6 +115,7 @@ def get_cards(
     set_id: Optional[str] = None,
     type_: Optional[str] = Query(None, alias="type"),
     rarity: Optional[str] = None,
+    category: Optional[str] = None,
     hp_min: Optional[int] = None,
     hp_max: Optional[int] = None,
     limit: Optional[int] = None,
@@ -131,6 +132,8 @@ def get_cards(
             if type_ not in card_types and type_ != trainer_type:
                 continue
         if rarity and card.get("rarity") != rarity:
+            continue
+        if category and card.get("category") != category:
             continue
         if hp_min is not None and int(card.get("hp", 0)) < hp_min:
             continue


### PR DESCRIPTION
## Summary
- extend `get_cards` with optional `category` query parameter
- filter cards by category if provided
- document `category` filtering in README with examples

## Testing
- `pytest -q`
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_6848a4212978832faf144b66789d5c8d