### PR TITLE
Add trainer_type filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ Eine einfache, offene API für Pokémon TCG Pocket Kartendaten – bereitgestell
 - Optionaler Query-Parameter `lang` bestimmt Sprache von Kartentext und Bild (Standard: `de`)
 - Weitere optionale Filter:
   - `set_id` – nur Karten eines bestimmten Sets
-  - `type` – Pokémon-Typ oder Trainer-Typ
+  - `type` – Pokémon-Typ
+  - `trainer_type` (Alias `trainerType`) – Trainer-Typ wie `Supporter` oder `Item`
   - `rarity` – Seltenheit der Karte
   - `category` – Kategorie der Karte (z. B. `Pokemon` oder `Trainer`)
   - `hp_min` / `hp_max` – minimale bzw. maximale KP
@@ -47,6 +48,7 @@ Eine einfache, offene API für Pokémon TCG Pocket Kartendaten – bereitgestell
 - Ohne Angabe wird nur Deutsch zurückgegeben.
 - Beispiel für Englisch: `/cards?lang=en`
 - Beispiel mit Filtern: `/cards?set_id=A2a&type=Metal&category=Pokemon&hp_min=100&limit=10`
+- Beispiel für Trainerkarten: `/cards?trainer_type=Supporter&category=Trainer`
 - Beispiel nur nach Kategorie: `/cards?category=Trainer`
 
 **Beispiel:**

--- a/main.py
+++ b/main.py
@@ -114,6 +114,7 @@ def get_cards(
     lang: str = "de",
     set_id: Optional[str] = None,
     type_: Optional[str] = Query(None, alias="type"),
+    trainer_type: Optional[str] = Query(None, alias="trainerType"),
     rarity: Optional[str] = None,
     category: Optional[str] = None,
     hp_min: Optional[int] = None,
@@ -128,9 +129,10 @@ def get_cards(
             continue
         if type_:
             card_types = card.get("types", [])
-            trainer_type = card.get("trainerType")
-            if type_ not in card_types and type_ != trainer_type:
+            if type_ not in card_types:
                 continue
+        if trainer_type and card.get("trainerType") != trainer_type:
+            continue
         if rarity and card.get("rarity") != rarity:
             continue
         if category and card.get("category") != category:


### PR DESCRIPTION
## Summary
- add a dedicated `trainer_type` filter
- document `trainer_type` in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848ab0f513c832fa703c9ec32cab449