### PR TITLE
Add suffix filter to card endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,14 @@ Eine einfache, offene API für Pokémon TCG Pocket Kartendaten – bereitgestell
   - `type` – Pokémon-Typ oder Trainer-Typ
   - `rarity` – Seltenheit der Karte
   - `category` – Kategorie der Karte (z. B. `Pokemon` oder `Trainer`)
+  - `suffix` – nur Karten mit bestimmtem Suffix (z. B. `EX`)
   - `hp_min` / `hp_max` – minimale bzw. maximale KP
   - `limit` & `offset` – Pagination der Ergebnisse
 - Ohne Angabe wird nur Deutsch zurückgegeben.
 - Beispiel für Englisch: `/cards?lang=en`
 - Beispiel mit Filtern: `/cards?set_id=A2a&type=Metal&category=Pokemon&hp_min=100&limit=10`
 - Beispiel nur nach Kategorie: `/cards?category=Trainer`
+- Beispiel mit Suffix: `/cards?suffix=EX`
 
 **Beispiel:**
 `https://ptcgp-api-production.up.railway.app/cards`

--- a/main.py
+++ b/main.py
@@ -116,6 +116,7 @@ def get_cards(
     type_: Optional[str] = Query(None, alias="type"),
     rarity: Optional[str] = None,
     category: Optional[str] = None,
+    suffix: Optional[str] = None,
     hp_min: Optional[int] = None,
     hp_max: Optional[int] = None,
     limit: Optional[int] = None,
@@ -134,6 +135,8 @@ def get_cards(
         if rarity and card.get("rarity") != rarity:
             continue
         if category and card.get("category") != category:
+            continue
+        if suffix and card.get("suffix") != suffix:
             continue
         if hp_min is not None and int(card.get("hp", 0)) < hp_min:
             continue


### PR DESCRIPTION
## Summary
- allow filtering cards by suffix via new `suffix` query parameter
- document `suffix` option in the README

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_6848ab0f07f4832fb5b737ee8bc614be