### PR TITLE
Add stage filter for cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Eine einfache, offene API für Pokémon TCG Pocket Kartendaten – bereitgestell
   - `trainer_type` (Alias `trainerType`) – Trainer-Typ wie `Supporter` oder `Item`
   - `rarity` – Seltenheit der Karte
   - `category` – Kategorie der Karte (z. B. `Pokemon` oder `Trainer`)
+  - `stage` – Entwicklungsstufe wie `Basic`, `Stage1` oder `Stage2`
   - `evolve_from` – nur Pokémon, die sich aus dem angegebenen entwickeln
   - `booster` – Name des Boosters (muss im Feld `boosters` der Karte enthalten sein)
   - `illustrator` – Name des Illustrators
@@ -61,6 +62,7 @@ Eine einfache, offene API für Pokémon TCG Pocket Kartendaten – bereitgestell
 - Beispiel mit Filtern: `/cards?set_id=A2a&type=Metal&category=Pokemon&hp_min=100&limit=10`
 - Beispiel für Trainerkarten: `/cards?trainer_type=Supporter&category=Trainer`
 - Beispiel nur nach Kategorie: `/cards?category=Trainer`
+- Beispiel nach Entwicklungsstufe: `/cards?stage=Stage1`
 - Beispiel nach Entwicklung: `/cards?evolve_from=Eevee`
 - Beispiel nach Illustrator: `/cards?illustrator=5ban Graphics`
 - Beispiel mit Suffix: `/cards?suffix=EX`

--- a/main.py
+++ b/main.py
@@ -118,6 +118,7 @@ def get_cards(
     rarity: Optional[str] = None,
     category: Optional[str] = None,
     evolve_from: Optional[str] = None,
+    stage: Optional[str] = None,
     booster: Optional[str] = None,
     illustrator: Optional[str] = None,
     suffix: Optional[str] = None,
@@ -131,8 +132,8 @@ def get_cards(
 ):
     """Alle Karten mit optionalen Filtern abrufen.
 
-    Unterstützt Filter für Set, Typ, Seltenheit, Kategorie, KP und
-    Rückzugskosten.
+    Unterstützt Filter für Set, Typ, Seltenheit, Kategorie, Entwicklungsstufe,
+    KP und Rückzugskosten.
     """
     result = []
     for card in _cards:
@@ -147,6 +148,8 @@ def get_cards(
         if rarity and card.get("rarity") != rarity:
             continue
         if category and card.get("category") != category:
+            continue
+        if stage and card.get("stage") != stage:
             continue
         if evolve_from:
             evo = card.get("evolveFrom")


### PR DESCRIPTION
## Summary
- extend `get_cards` with optional `stage` parameter to filter by evolution stage
- document the new filter and add an example in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68493ff0bc48832fb34003c91e6caeb9