### PR TITLE
Add SKIP_IMAGE_CHECKS option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Eine einfache, offene API für Pokémon TCG Pocket Kartendaten – bereitgestell
    ```bash
    pytest
    ```
+5. Optional kann die Umgebungsvariable `SKIP_IMAGE_CHECKS=1` gesetzt werden,
+   um die Prüfung von Bild-URLs (HTTP-HEAD) zu überspringen.
 
 ---
 ## Endpunkte
@@ -62,6 +64,8 @@ Eine einfache, offene API für Pokémon TCG Pocket Kartendaten – bereitgestell
 - Ohne Angabe wird nur Deutsch zurückgegeben.
   Das hochauflösende Bild (`high.webp`) wird nur dann verwendet, wenn es
   existiert; andernfalls liefert die API `low.webp`.
+  Setze `SKIP_IMAGE_CHECKS`, um diese Prüfung zu deaktivieren und immer
+  `high.webp` zu erhalten.
 
 **Beispiele (DE/EN):**
 `https://ptcgp-api-production.up.railway.app/cards?set_id=A2a&type=Metal&limit=10`

--- a/main.py
+++ b/main.py
@@ -115,6 +115,8 @@ _search_index = _build_search_index(_cards)
 def _image_url(lang: str, set_id: str, local_id: str) -> str:
     base = f"https://assets.tcgdex.net/{lang}/tcgp/{set_id}/{local_id}"
     high = f"{base}/high.webp"
+    if os.getenv("SKIP_IMAGE_CHECKS"):
+        return high
     if high not in _image_cache:
         try:
             resp = requests.head(high)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,9 @@
 import os
 import sys
 
+# Skip external image checks during tests
+os.environ["SKIP_IMAGE_CHECKS"] = "1"
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fastapi.testclient import TestClient


### PR DESCRIPTION
## Summary
- allow disabling image HEAD checks via `SKIP_IMAGE_CHECKS`
- honor this environment variable in tests
- document the option in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858fbd4a9d8832f9cdb5e6067bba107