### PR TITLE
Add edge case API tests

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -118,3 +118,21 @@ def test_deck_and_group_flow():
     resp = client.get(f"/groups/{group_id}")
     assert resp.status_code == 200
     assert user in resp.json()["members"]
+
+
+def test_get_unknown_card():
+    resp = client.get("/cards/unknown")
+    assert resp.status_code == 404
+
+
+def test_get_unknown_set():
+    resp = client.get("/sets/unknown")
+    assert resp.status_code == 404
+
+
+def test_trade_matches_empty(monkeypatch):
+    import main
+    monkeypatch.setattr(main, "_users", {})
+    resp = client.get("/trades/matches")
+    assert resp.status_code == 200
+    assert resp.json() == []


### PR DESCRIPTION
## Summary
- test 404 responses on unknown card and set IDs
- ensure trade matching returns empty list if no users are present

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685920f70de8832fbb701c380ec09916