### PR TITLE
Improve packaging and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - run: ruff check .
       - run: pip-audit
       - name: Snyk scan
-        uses: snyk/actions/python@v1
+        uses: snyk/actions/python@0.4.0
         with:
           command: test
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,38 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements*.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
       - run: pip install -r requirements.txt -r requirements-dev.txt
       - run: pre-commit run --all-files --show-diff-on-failure
       - run: ruff check .
       - run: pip-audit
+      - name: Snyk scan
+        uses: snyk/actions/python@v1
+        with:
+          command: test
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
       - run: pytest --cov=ptcgp_api --cov-report=xml
       - uses: actions/upload-artifact@v4
         with:
           name: coverage
           path: coverage.xml
+      - name: Upload Railway logs
+        run: |
+          if command -v railway >/dev/null; then
+            railway logs --follow --detach > latest_railway.log &
+            sleep 5
+            pkill -f "railway logs" || true
+            cat latest_railway.log
+          fi
+        continue-on-error: true
+      - uses: actions/upload-artifact@v4
+        with:
+          name: railway-logs
+          path: latest_railway.log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
       - run: ruff check .
       - run: pip-audit
       - name: Snyk scan
+        if: ${{ secrets.SNYK_TOKEN != '' }}
         uses: snyk/actions/python@0.4.0
         with:
           command: test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@
 - Global exception handler that logs unexpected errors.
 - GitHub Actions workflow with `ruff` linting and tests.
 - `IMAGE_TIMEOUT` environment variable for configurable image request timeout.
+- Packaging metadata in `pyproject.toml` allowing `pip install -e .`.
+- Dependency caching and Snyk scanning in CI workflow.
+- `pytest.ini` enabling `pytest-timeout`.
 - Package versions pinned in `requirements*.txt` for reproducible installs.
 - Coverage reporting via `pytest-cov` in CI.
 
@@ -26,6 +29,9 @@
 - Image URL checks cached for 24 hours to improve performance.
 - CI workflow uses `ruff check` for compatibility.
 - Async tests share a session-scoped event loop.
+
+### Removed
+- Manual `sys.path` adjustments in tests; project installs as editable package.
 
 - Structured JSON logging using structlog with file rotation.
 - CI now runs pre-commit and pip-audit for security scanning.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - `IMAGE_TIMEOUT` environment variable for configurable image request timeout.
 - Packaging metadata in `pyproject.toml` allowing `pip install -e .`.
 - Dependency caching and Snyk scanning in CI workflow.
+- Snyk scan skipped on forked PRs when token is unavailable.
 - `pytest.ini` enabling `pytest-timeout`.
 - Package versions pinned in `requirements*.txt` for reproducible installs.
 - Coverage reporting via `pytest-cov` in CI.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Eine offene FastAPI-Anwendung zum Bereitstellen von Pokémon TCG Pocket Daten.
 ```bash
 python3 -m venv .venv
 source .venv/bin/activate
-pip install -r requirements.txt -r requirements-dev.txt
+pip install -e . -r requirements-dev.txt
 ```
 
 ## Starten
@@ -28,7 +28,7 @@ uvicorn main:app --reload
 
 ## Tests
 ```bash
-pytest
+pytest --cov=ptcgp_api --cov-report=term-missing
 ```
 Optionale Benchmarks:
 ```bash
@@ -50,4 +50,6 @@ pytest --benchmark-only
 Weitere Details siehe `CHANGELOG.md`.
 
 ## Entwicklung
-Führe `pre-commit install` aus, um automatische Formatierung und Linting sicherzustellen. Logs werden strukturiert in `logs/app.log` mit Rotationsdateien geschrieben.
+Führe `pre-commit install` aus, um automatische Formatierung und Linting sicherzustellen.
+Logs werden strukturiert in `logs/app.log` mit Rotationsdateien geschrieben.
+Siehe `.env.example` für alle verfügbaren Umgebungsvariablen.

--- a/README.md
+++ b/README.md
@@ -53,3 +53,4 @@ Weitere Details siehe `CHANGELOG.md`.
 Führe `pre-commit install` aus, um automatische Formatierung und Linting sicherzustellen.
 Logs werden strukturiert in `logs/app.log` mit Rotationsdateien geschrieben.
 Siehe `.env.example` für alle verfügbaren Umgebungsvariablen.
+Der CI-Workflow führt einen Snyk-Scan nur aus, wenn ein `SNYK_TOKEN` bereitsteht.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,3 +3,23 @@ line-length = 88
 
 [tool.ruff.lint]
 select = ["E", "F"]
+
+[project]
+name = "ptcgp-api"
+version = "0.1.0"
+description = "Pokémon TCG Pocket Data API"
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = [
+    "fastapi==0.115.13",
+    "uvicorn[standard]==0.34.3",
+    "httpx==0.28.1",
+    "cachetools==6.1.0",
+    "structlog==24.1.0",
+]
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+addopts = --timeout=15
+asyncio_mode = auto

--- a/tests/performance/test_filter_perf.py
+++ b/tests/performance/test_filter_perf.py
@@ -1,10 +1,6 @@
 # ruff: noqa: E402
 # flake8: noqa
 import os
-import sys
-
-base = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "src"))
-sys.path.insert(0, base)
 
 import pytest
 from fastapi.testclient import TestClient

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,11 +1,5 @@
 import logging
 import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")),
-)
 
 import pytest  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402

--- a/tests/test_image_cache.py
+++ b/tests/test_image_cache.py
@@ -58,3 +58,34 @@ async def test_image_url_timeout(monkeypatch, caplog):
     high = "https://assets.tcgdex.net/de/tcgp/A2a/001/high.webp"
     assert cache[high] is False
     assert any("HEAD request failed" in r.message for r in caplog.records)
+
+
+async def test_image_url_retry(monkeypatch):
+    os.environ.pop("SKIP_IMAGE_CHECKS", None)
+
+    calls = []
+
+    class DummyClient:
+        def __init__(self):
+            self.first = True
+
+        async def head(self, url, timeout=3):
+            calls.append(url)
+            if self.first:
+                self.first = False
+                raise httpx.HTTPError("boom")
+
+            class R:
+                status_code = 200
+
+            return R()
+
+    client = DummyClient()
+    monkeypatch.setattr(
+        cards_routes,
+        "_image_cache",
+        TTLCache(maxsize=10, ttl=10),
+    )
+    url = await cards_routes._image_url(client, "de", "A2a", "001")
+    assert url.endswith("high.webp")
+    assert len(calls) == 2


### PR DESCRIPTION
## Summary
- package project with PEP 621 metadata
- cache dependencies and run Snyk in CI
- install project for tests and drop sys.path hacks
- add pytest.ini for pytest-timeout
- retry failed HEAD requests once when fetching images
- document setup and env vars

## Testing
- `pre-commit run --files pyproject.toml tests/test_api.py tests/performance/test_filter_perf.py README.md CHANGELOG.md .github/workflows/ci.yml pytest.ini src/ptcgp_api/routes/cards.py tests/test_image_cache.py`
- `pytest -q`
- `ruff check .`
- `pip-audit`


------
https://chatgpt.com/codex/tasks/task_e_685b2f18f850832fa817ec9f881dcdef