### PR TITLE
Fix startup docs and import paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
           key: ${{ runner.os }}-pip-${{ hashFiles('requirements*.txt') }}
           restore-keys: |
             ${{ runner.os }}-pip-
-      - run: pip install -r requirements.txt -r requirements-dev.txt
+      - run: pip install -e . -r requirements-dev.txt
       - run: pre-commit run --all-files --show-diff-on-failure
       - run: ruff check .
       - run: pip-audit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Image URL checks cached for 24 hours to improve performance.
 - CI workflow uses `ruff check` for compatibility.
 - Async tests share a session-scoped event loop.
+- Startup instructions now reference `ptcgp_api:app` and document Railway command.
 
 ### Removed
 - Manual `sys.path` adjustments in tests; project installs as editable package.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,12 @@ pip install -e . -r requirements-dev.txt
 
 ## Starten
 ```bash
-uvicorn main:app --reload
+uvicorn ptcgp_api:app --reload
+```
+
+### Railway
+```bash
+uvicorn ptcgp_api:app --host 0.0.0.0 --port $PORT
 ```
 
 ## Umgebungsvariablen

--- a/tests/performance/test_filter_perf.py
+++ b/tests/performance/test_filter_perf.py
@@ -4,7 +4,7 @@ import os
 
 import pytest
 from fastapi.testclient import TestClient
-from main import app
+from ptcgp_api import app
 
 os.environ["SKIP_IMAGE_CHECKS"] = "1"
 os.environ["API_KEY"] = "testkey"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,7 +3,7 @@ import os
 
 import pytest  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
-from main import app  # noqa: E402
+from ptcgp_api import app  # noqa: E402
 import ptcgp_api.routes.users as users_routes  # noqa: E402
 
 os.environ["SKIP_IMAGE_CHECKS"] = "1"


### PR DESCRIPTION
## Summary
- document how to start the API package directly
- mention Railway start command in README
- adjust tests to import `app` from package
- install package during CI runs
- note new startup instruction in changelog

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b3998e598832f839476f9d90cb667