### PR TITLE
Integrate Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
 - `pytest.ini` enabling `pytest-timeout`.
 - Package versions pinned in `requirements*.txt` for reproducible installs.
 - Coverage reporting via `pytest-cov` in CI.
+- Dependabot konfiguriert automatische Updates für Python-Pakete und
+  GitHub Actions.
 
 ### Changed
 - Endpoints now await image URL resolution.

--- a/README.md
+++ b/README.md
@@ -59,3 +59,8 @@ Führe `pre-commit install` aus, um automatische Formatierung und Linting sicher
 Logs werden strukturiert in `logs/app.log` mit Rotationsdateien geschrieben.
 Siehe `.env.example` für alle verfügbaren Umgebungsvariablen.
 Der CI-Workflow führt einen Snyk-Scan nur aus, wenn ein `SNYK_TOKEN` bereitsteht.
+
+## Dependabot
+Dieses Repository nutzt Dependabot, um Python-Abhängigkeiten und GitHub Actions
+wöchentlich automatisch zu aktualisieren. Aktiviere dazu Dependabot Alerts und
+Security Updates in den Repository-Einstellungen.

--- a/src/ptcgp_api/__init__.py
+++ b/src/ptcgp_api/__init__.py
@@ -1,3 +1,8 @@
+"""PTCGP Data API main application.
+
+CI checks run for every commit, including automatic Dependabot updates.
+"""
+
 import logging
 import logging.handlers
 import os


### PR DESCRIPTION
## Summary
- automate dependency updates with a Dependabot config
- note Dependabot usage in README and module docstring
- track Dependabot integration in CHANGELOG

## Testing
- `pre-commit run --files .github/dependabot.yml src/ptcgp_api/__init__.py README.md CHANGELOG.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685beccb0778832fb19a94e738faf9b5