### PR TITLE
Add pre-commit cache to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
       - run: pip install -e . -r requirements-dev.txt
+      - name: Cache pre-commit
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: ${{ runner.os }}-precommit-${{ hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: ${{ runner.os }}-precommit-
       - run: pre-commit run --all-files --show-diff-on-failure
       - run: ruff check .
       - run: pip-audit


### PR DESCRIPTION
## Summary
- speed up workflow by caching pre-commit

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685c1f5e6c18832f9935620b9af113a7