### PR TITLE
Fix logs path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,13 +40,13 @@ jobs:
       - name: Upload Railway logs
         run: |
           if command -v railway >/dev/null; then
-            railway logs --follow --detach > latest_railway.log &
+            railway logs --follow --detach > logs/latest_railway.log &
             sleep 5
             pkill -f "railway logs" || true
-            cat latest_railway.log
+            cat logs/latest_railway.log
           fi
         continue-on-error: true
       - uses: actions/upload-artifact@v4
         with:
           name: railway-logs
-          path: latest_railway.log
+          path: logs/latest_railway.log


### PR DESCRIPTION
## Summary
- adjust logs path for Railway log capture in CI

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c229ddde8832f85db2a370d83280b