### PR TITLE
Fix dependabot schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,9 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 5
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"


### PR DESCRIPTION
## Summary
- update dependabot schedule to check daily

## Testing
- `pre-commit run --all-files --show-diff-on-failure`
- `pytest --cov=ptcgp_api --cov-report=term-missing`

------
https://chatgpt.com/codex/tasks/task_e_685c7da68dc0832f905d61cde16bbae2