### PR TITLE
docs: note daily Dependabot checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Endpoints now await image URL resolution.
 - Image URL checks cached for 24 hours to improve performance.
 - CI workflow uses `ruff check` for compatibility.
+- Dependabot aktualisiert Abhängigkeiten nun täglich und jeder PR läuft durch die komplette CI-Pipeline.
 - Async tests share a session-scoped event loop.
 - Startup instructions now reference `ptcgp_api:app` and document Railway command.
 

--- a/README.md
+++ b/README.md
@@ -62,5 +62,6 @@ Der CI-Workflow führt einen Snyk-Scan nur aus, wenn ein `SNYK_TOKEN` bereitsteh
 
 ## Dependabot
 Dieses Repository nutzt Dependabot, um Python-Abhängigkeiten und GitHub Actions
-wöchentlich automatisch zu aktualisieren. Aktiviere dazu Dependabot Alerts und
-Security Updates in den Repository-Einstellungen.
+täglich automatisch zu aktualisieren. Jeder Dependabot-PR durchläuft die
+komplette CI-Pipeline inklusive Linting, Tests und Security-Audit. Aktiviere
+dazu Dependabot Alerts und Security Updates in den Repository-Einstellungen.


### PR DESCRIPTION
## Summary
- update docs that Dependabot runs daily and triggers full CI

## Testing
- `pre-commit run --files README.md CHANGELOG.md .github/dependabot.yml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c8a5e09dc832fa62d158e22edf28e