### PR TITLE
Enable CI coverage display

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           command: test
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-      - run: pytest --cov=ptcgp_api --cov-report=xml --cov-fail-under=80
+      - run: pytest --cov=. --cov-report=term-missing --cov-report=xml --cov-fail-under=80
       - uses: actions/upload-artifact@v4
         with:
           name: coverage

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ uvicorn ptcgp_api:app --host 0.0.0.0 --port $PORT
 
 ## Tests
 ```bash
-pytest --cov=ptcgp_api --cov-report=term-missing
+pytest --cov=. --cov-report=term-missing
 ```
 Optionale Benchmarks:
 ```bash


### PR DESCRIPTION
## Summary
- show coverage table in CI by passing `--cov=. --cov-report=term-missing`
- update README test command to match CI coverage flag

## Testing
- `pre-commit run --files .github/workflows/ci.yml README.md`
- `pytest -q`
- `pytest --cov=. --cov-report=term-missing -q`


------
https://chatgpt.com/codex/tasks/task_e_685c8caeef4c832fad79aab530d57396