### PR TITLE
Ensure dependabot schedule compliance

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    open-pull-requests-limit: 5
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"


### PR DESCRIPTION
## Summary
- adjust dependabot schedule for GitHub Actions to weekly

## Testing
- `pre-commit run --files .github/dependabot.yml`
- `pytest --cov=. --cov-report=term-missing --cov-fail-under=90`

------
https://chatgpt.com/codex/tasks/task_e_685ddff532e0832f94e595e107bf2d0b